### PR TITLE
CI: Add linux/arm64 Platform To CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   schedule:
     - cron:  '*/30 * * * *'
-  issue_comment:                                     
+  issue_comment:
     types: [created]
   workflow_dispatch:
   push:
@@ -13,12 +13,15 @@ on:
 concurrency:
   group: "docker"
   cancel-in-progress: false
-  
+
 jobs:
   build-and-push-image:
     strategy:
       fail-fast: false
       matrix:
+        platform:
+          - linux/amd64 # x86_64
+          - linux/arm64 # AArch64/ ARM v8
         registry: ['', 'ghcr.io']
         version: ['', 'reg-']
         prefix: ['', 'base-', 'go-', 'node-', 'exts-']
@@ -56,16 +59,26 @@ jobs:
       - name: Fetch latest Hugo release
         id: release
         run: curl https://api.github.com/repos/gohugoio/hugo/releases/latest -s | jq .tag_name -r | awk '{print "version="substr($1,2)}' >> $GITHUB_OUTPUT
-        
-      - name: Check if the image exists
-        if: steps.release.outputs.version != 'ull'
+
+      # Github Actions don't offer a native way to access matrix.platform array count
+      # Hard coded value, assume that the images are unique per arhitecture
+      # For Docker container registry:
+      # We don't check if the arhitecture actually exists, we only expect if two images exist
+      # For Github container registry:
+      # No easy option to check for image arhitecture via API, tools like skopeo can be used
+      - name: Log architecture
+        id: arch
+        run: |
+          echo ${{ matrix.platform }} | awk -F '/' '{print "image_arch="$2}' >> "$GITHUB_ENV"
+      - name: Check if image exists for arhitecture
+        if: steps.release.outputs.version != 'null'
         id: check
         run: |
           if [[ -z "${{ matrix.registry }}" ]];
           then
             curl -s \
               -- url https://hub.docker.com/v2/namespaces/hugomods/repositories/hugo/tags/${{ matrix.version }}${{ matrix.prefix }}${{ steps.release.outputs.version }} \
-              | jq 'has("name")' \
+              | jq 'try(.images)[].architecture | index("${{ env.image_arch }}") != null // false' \
               | awk '{print "exists="$1}' \
               >> $GITHUB_OUTPUT;
           else
@@ -77,7 +90,7 @@ jobs:
               | awk '{print "exists="$1}' \
               >> $GITHUB_OUTPUT;
           fi;
-      
+
       - name: Checkout repository
         if: steps.check.outputs.exists == 'false'
         uses: actions/checkout@v3
@@ -110,6 +123,7 @@ jobs:
           tags: hugo-alpine:latest
           build-args: |
             GCC=${{ matrix.gcc }}
+          platforms: ${{ matrix.platform }}
 
       - name: Build the builder image
         if: steps.check.outputs.exists == 'false'
@@ -122,6 +136,7 @@ jobs:
           build-args: |
             HUGO_VERSION=v${{ steps.release.outputs.version }}
             HUGO_EXTENDED=${{ matrix.extended }}
+          platforms: ${{ matrix.platform }}
 
       - name: Build and export to Docker
         if: steps.check.outputs.exists == 'false'
@@ -136,11 +151,12 @@ jobs:
           build-contexts: |
             alpine=docker-image://hugo-alpine:latest
             builder=docker-image://hugo-builder:latest
+          platforms: ${{ matrix.platform }}
 
       - name: Test
         if: steps.check.outputs.exists == 'false'
         run: |
-          docker run --rm -v $PWD/site:/src hugomods/hugo:${{ matrix.version }}${{ matrix.prefix }}test hugo
+          docker run --platform ${{ matrix.platform }} --rm -v $PWD/site:/src hugomods/hugo:${{ matrix.version }}${{ matrix.prefix }}test hugo
 
       - name: Build and push
         if: steps.check.outputs.exists == 'false'
@@ -155,3 +171,4 @@ jobs:
           build-contexts: |
             alpine=docker-image://hugo-alpine:latest
             builder=docker-image://hugo-builder:latest
+          platforms: ${{ matrix.platform }}


### PR DESCRIPTION
In addition to `linux/amd64`, CI will also build and ship `linux/arm64` images.

The CI will be relatively slow since it has to run twice the amount of jobs on the same runners and emulating arm64.
It is possible to speed up this by archiving digests and uploading them separately.

Resolves #33