### PR TITLE
Replace Embedded Dart SASS with regular Dart SASS

### DIFF
--- a/docker/hugo/snippets/exts
+++ b/docker/hugo/snippets/exts
@@ -1,6 +1,6 @@
 # install Embedded Dart SASS.
-RUN apk add dart-sass-embedded --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
-RUN apk add --no-cache dart-sass-embedded
+RUN apk add dart-sass --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN apk add --no-cache dart-sass
 
 # install packages.
 RUN npm i -g postcss-cli autoprefixer @fullhuman/postcss-purgecss rtlcss


### PR DESCRIPTION
Add arm64 arch support for the `exts` images.

Closed #43.