### PR TITLE
Replace `gcc` with `libc6-compat`, `libstdc++` on final stage

### DIFF
--- a/docker/hugo/snippets/common
+++ b/docker/hugo/snippets/common
@@ -1,8 +1,5 @@
 ARG HUGO_EXTENDED=
 
-# gcc is required by extended Hugo.
-RUN if [[ -n "$HUGO_EXTENDED" ]]; then apk add --no-cache gcc; fi
-
 RUN apk add --update --no-cache ca-certificates
 
 # copy Hugo binary from builder.

--- a/docker/hugo/snippets/common
+++ b/docker/hugo/snippets/common
@@ -1,5 +1,8 @@
 ARG HUGO_EXTENDED=
 
+# libc6-compat & libstdc++ are required for extended SASS libraries
+RUN if [[ -n "$HUGO_EXTENDED" ]]; then apk add --no-cache libc6-compat libstdc++; fi
+
 RUN apk add --update --no-cache ca-certificates
 
 # copy Hugo binary from builder.


### PR DESCRIPTION
Refer to https://github.com/gohugoio/hugo/blob/2da4ec5738e9b9060aab37247312244e1b8a318d/Dockerfile#L33-L36.

Closes #69 