### PR TITLE
Add timezone data to common

### DIFF
--- a/docker/hugo/snippets/common
+++ b/docker/hugo/snippets/common
@@ -3,7 +3,7 @@ ARG HUGO_EXTENDED=
 # libc6-compat & libstdc++ are required for extended SASS libraries
 RUN if [[ -n "$HUGO_EXTENDED" ]]; then apk add --no-cache libc6-compat libstdc++; fi
 
-RUN apk add --update --no-cache ca-certificates
+RUN apk add --update --no-cache ca-certificates tzdata
 
 # copy Hugo binary from builder.
 COPY --from=builder /usr/bin/hugo /usr/bin/hugo

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -1,5 +1,6 @@
 baseURL: 'http://example.org/'
 languageCode: en-us
+timeZone: America/Los_Angeles
 title: Hugo Example Site
 cascade:
   - _target:


### PR DESCRIPTION
The image requires timezone data to handle [timeZone](https://gohugo.io/getting-started/configuration/#timezone) setting in Hugo configuration files.