### PR TITLE
fix(tests): support default export for postcss-purgecss

### DIFF
--- a/tests/postcss/postcss.config.js
+++ b/tests/postcss/postcss.config.js
@@ -1,13 +1,15 @@
-const autoprefixer = require('/usr/local/lib/node_modules/autoprefixer')
-const rtlcss = require('/usr/local/lib/node_modules/rtlcss')
-const purgecss = require('/usr/local/lib/node_modules/@fullhuman/postcss-purgecss').purgeCSSPlugin
+const autoprefixer = require("/usr/local/lib/node_modules/autoprefixer");
+const rtlcss = require("/usr/local/lib/node_modules/rtlcss");
+// Support both CJS + ESM export shapes across postcss-purgecss versions.
+const purgecssMod = require("/usr/local/lib/node_modules/@fullhuman/postcss-purgecss");
+const purgecss = purgecssMod.default ?? purgecssMod.purgeCSSPlugin ?? purgecssMod;
 
 module.exports = {
   plugins: [
-      autoprefixer,
-      purgecss({
-        content: ['index.html']
-      }),
-      rtlcss
-  ]
-}
+    autoprefixer,
+    purgecss({
+      content: ["index.html"],
+    }),
+    rtlcss,
+  ],
+};


### PR DESCRIPTION
Fix PostCSS smoke test failure caused by @fullhuman/postcss-purgecss export shape changes.

- Update tests/postcss/postcss.config.js to support default export (and older shapes via fallback).
- Verified by running: docker run --rm -v "$PWD/tests/postcss:/src" -w /src hugomods/hugo:test postcss ./main.css


Fixes #126